### PR TITLE
[ to master ] Add a Procfile

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: gunicorn -w 4 uaainvite:app

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,7 +1,6 @@
 ---
 applications:
 - name: invite
-  command: gunicorn -w 4 uaainvite:app
   host: invite
 # env:
 #   UAA_BASE_URL: https://uaa.bosh-lite.com

--- a/manifest_production.yml
+++ b/manifest_production.yml
@@ -3,4 +3,3 @@ applications:
 - name: invite
   no-hostname: true
   domain: invite.cloud.gov
-  command: gunicorn -w 4 uaainvite:app


### PR DESCRIPTION
It seems like the `command:` stanza within the original manifest
examples was not working. The following error was being generated during
deployment. While the documentation mentions the use of either a
Procfile or `-c` in the `cf push` call. I wasn't able to deploy the
application without a Procfile

```
-------> Buildpack version 1.5.10
 !     Warning: Your application is missing a Procfile. This file tells Cloud Foundry how to run your application.
 !     Learn more: https://docs.cloudfoundry.org/buildpacks/prod-server.html#procfile
[ ... ]
 No start command specified by buildpack or via Procfile.
 App will not start unless a command is provided at runtime.
 Exit status 0
 Staging complete
```

Duplicate of #12 because of #14.